### PR TITLE
Wait for stream to exists

### DIFF
--- a/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/StreamBigqueryChangeConsumerTest.java
+++ b/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/StreamBigqueryChangeConsumerTest.java
@@ -108,7 +108,7 @@ public class StreamBigqueryChangeConsumerTest extends BaseBigqueryTest {
   }
 
   @Test
-  @Disabled
+  @Disabled // needs GCP for testing. doesnt work with emulator
   public void testSchemaChanges() throws Exception {
     String dest = "testc.inventory.customers";
     // apply stream data every 2 seconds
@@ -147,7 +147,7 @@ public class StreamBigqueryChangeConsumerTest extends BaseBigqueryTest {
         assertTableRowsMatch(dest, 1, "first_name = 'SallyUSer2'");
         assertTableRowsMatch(dest, 1, "last_name is null");
         assertTableRowsMatch(dest, 1, "id = 1004 AND __op = 'd'");
-//        assertTableRowsMatch(dest, 1, "test_varchar_column = 'value1'");
+        assertTableRowsMatch(dest, 1, "test_varchar_column = 'value1'");
         return true;
       } catch (AssertionError | Exception e) {
         LOGGER.error("Error: {}", e.getMessage());
@@ -164,7 +164,7 @@ public class StreamBigqueryChangeConsumerTest extends BaseBigqueryTest {
         prettyPrint(dest);
         assertTableRowsAboveEqual(dest, 9);
         assertTableRowsMatch(dest, 1, "first_name = 'User3'");
-//        assertTableRowsMatch(dest, 1, "test_varchar_column = 'test_varchar_value3'");
+        assertTableRowsMatch(dest, 1, "test_varchar_column = 'test_varchar_value3'");
         return true;
       } catch (AssertionError | Exception e) {
         LOGGER.error("Error: {}", e.getMessage());

--- a/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/StreamBigqueryChangeConsumerTest.java
+++ b/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/StreamBigqueryChangeConsumerTest.java
@@ -39,7 +39,6 @@ public class StreamBigqueryChangeConsumerTest extends BaseBigqueryTest {
   @BeforeAll
   public static void setup() throws InterruptedException {
     bqClient = BigQueryDB.bigQueryClient();
-//    truncateTables();
     Thread.sleep(5000);
   }
 
@@ -116,10 +115,10 @@ public class StreamBigqueryChangeConsumerTest extends BaseBigqueryTest {
     TableId tableId = getTableId(dest);
     String query2 = "ALTER table  " + tableId.getDataset() + "." + tableId.getTable() + " SET OPTIONS " +
         "(max_staleness = INTERVAL '0-0 0 0:0:2' YEAR TO SECOND);";
-    bqClient.query(QueryJobConfiguration.newBuilder(query2).build());
     //
     Awaitility.await().atMost(Duration.ofSeconds(180)).until(() -> {
       try {
+        bqClient.query(QueryJobConfiguration.newBuilder(query2).build());
         assertTableRowsAboveEqual(dest, 4);
         return true;
       } catch (AssertionError | Exception e) {
@@ -144,7 +143,7 @@ public class StreamBigqueryChangeConsumerTest extends BaseBigqueryTest {
       try {
         prettyPrint(dest);
         assertTableRowsAboveEqual(dest, 8);
-        assertTableRowsMatch(dest, 2, "__op = 'u'");
+        assertTableRowsAboveEqual(dest, 3, "__op = 'u'");
         assertTableRowsMatch(dest, 1, "first_name = 'SallyUSer2'");
         assertTableRowsMatch(dest, 1, "last_name is null");
         assertTableRowsMatch(dest, 1, "id = 1004 AND __op = 'd'");

--- a/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/shared/BigQueryGCP.java
+++ b/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/shared/BigQueryGCP.java
@@ -10,6 +10,7 @@ package io.debezium.server.bigquery.shared;
 
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
+import io.debezium.server.bigquery.BaseBigqueryTest;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,6 +42,7 @@ public class BigQueryGCP implements QuarkusTestResourceLifecycleManager {
   @Override
   public Map<String, String> start() {
     bqClient = bigQueryClient();
+    BaseBigqueryTest.dropTables();
     Map<String, String> config = new ConcurrentHashMap<>();
     // batch
     // src/test/resources/application.properties


### PR DESCRIPTION
This should improve testing, and stream not found errors. 

when a new table created its stream is not immediately available and then the consumer throws with stream not found error. so we are adding a waiting and check on stream existence