### PR TITLE
Revert "Bump io.smallrye:jandex-maven-plugin from 3.2.7 to 3.3.0 (#266)"

### DIFF
--- a/debezium-server-bigquery-sinks/pom.xml
+++ b/debezium-server-bigquery-sinks/pom.xml
@@ -130,7 +130,7 @@
             <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.2.7</version>
                 <executions>
                     <execution>
                         <id>make-index</id>


### PR DESCRIPTION
This reverts commit f4d4388d02f0c1247d598b5781c3f5fa2d9f1dcf.

resolves #269
