### PR TITLE
Consume nested data to json fields

### DIFF
--- a/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/BaseRecordConverter.java
+++ b/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/BaseRecordConverter.java
@@ -118,7 +118,7 @@ public abstract class BaseRecordConverter implements RecordConverter {
   }
 
   protected Field getStructField(JsonNode jsonSchemaFieldNode, String fieldName) {
-    if (debeziumConfig.common().structAsJson()) {
+    if (debeziumConfig.common().nestedAsJson()) {
       return Field.of(fieldName, StandardSQLTypeName.JSON);
     }
     // recursive call for nested fields

--- a/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/BaseRecordConverter.java
+++ b/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/BaseRecordConverter.java
@@ -103,9 +103,7 @@ public abstract class BaseRecordConverter implements RecordConverter {
               fields.add(Field.newBuilder(fieldName, StandardSQLTypeName.STRUCT, FieldList.of(geometryFields)).build());
               break;
             default:
-              // recursive call for nested fields
-              ArrayList<Field> subFields = schemaFields(jsonSchemaFieldNode);
-              fields.add(Field.newBuilder(fieldName, StandardSQLTypeName.STRUCT, FieldList.of(subFields)).build());
+              fields.add(getStructField(jsonSchemaFieldNode, fieldName));
               break;
           }
           break;
@@ -117,6 +115,15 @@ public abstract class BaseRecordConverter implements RecordConverter {
     }
 
     return fields;
+  }
+
+  protected Field getStructField(JsonNode jsonSchemaFieldNode, String fieldName) {
+    if (debeziumConfig.common().structAsJson()) {
+      return Field.of(fieldName, StandardSQLTypeName.JSON);
+    }
+    // recursive call for nested fields
+    ArrayList<Field> subFields = schemaFields(jsonSchemaFieldNode);
+    return Field.newBuilder(fieldName, StandardSQLTypeName.STRUCT, FieldList.of(subFields)).build();
   }
 
   public static String removeTemporalValueTrailingZ(String input) {
@@ -247,12 +254,17 @@ public abstract class BaseRecordConverter implements RecordConverter {
         }
         break;
       case JSON:
-        try {
-          parentNode.replace(fieldName, mapper.readTree(value.textValue()));
-        } catch (JsonProcessingException e) {
-          throw new DebeziumException("Failed to process JSON field: " + fieldName + " value: " + value.textValue(), e);
+        if (value.isTextual()) {
+          try {
+            parentNode.replace(fieldName, mapper.readTree(value.textValue()));
+          } catch (JsonProcessingException e) {
+            throw new DebeziumException("Failed to process JSON field: " + fieldName + " value: " + value.textValue(), e);
+          }
         }
-        break;
+        if (value.isObject()) {
+          break;
+        }
+        throw new DebeziumException("Unexpected JSON value: " + fieldName + " value-type: " + value.getNodeType() + "value: " + value.textValue());
       case DATE:
       case DATETIME:
       case TIME:

--- a/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/BatchBigqueryChangeConsumer.java
+++ b/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/BatchBigqueryChangeConsumer.java
@@ -99,13 +99,17 @@ public class BatchBigqueryChangeConsumer<T> extends BaseChangeConsumer {
       WriteChannelConfiguration.Builder wCCBuilder = WriteChannelConfiguration
           .newBuilder(tableId, FormatOptions.json())
           .setWriteDisposition((config.writeDisposition()))
-          .setClustering(clustering)
           .setSchema(schema)
-          .setTimePartitioning(timePartitioning)
           .setSchemaUpdateOptions(schemaUpdateOptions)
           .setCreateDisposition(config.createDisposition())
           .setMaxBadRecords(0)
           .setCreateSession(true);
+
+      if (!config.common().structAsJson()) {
+        wCCBuilder
+            .setTimePartitioning(timePartitioning)
+            .setClustering(clustering);
+      }
 
       //WriteChannel implementation to stream data into a BigQuery table. 
       try (TableDataWriteChannel writer = bqClient.writer(wCCBuilder.build())) {

--- a/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/BatchBigqueryChangeConsumer.java
+++ b/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/BatchBigqueryChangeConsumer.java
@@ -105,7 +105,7 @@ public class BatchBigqueryChangeConsumer<T> extends BaseChangeConsumer {
           .setMaxBadRecords(0)
           .setCreateSession(true);
 
-      if (!config.common().structAsJson()) {
+      if (!config.common().nestedAsJson()) {
         wCCBuilder
             .setTimePartitioning(timePartitioning)
             .setClustering(clustering);

--- a/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/BatchRecordConverter.java
+++ b/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/BatchRecordConverter.java
@@ -39,9 +39,10 @@ public class BatchRecordConverter extends BaseRecordConverter {
     }
 
     try {
-      // process JSON event field values, handle data values
+      // handle event values
       if (schema != null) {
         for (Field f : schema.getFields()) {
+          // skip non-existing values
           if (!value.has(f.getName())) {
             continue;
           }

--- a/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/CommonConfig.java
+++ b/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/CommonConfig.java
@@ -21,4 +21,8 @@ public interface CommonConfig {
   @WithDefault("NoBatchSizeWait")
   String batchSizeWaitName();
 
+  @WithName("debezium.sink.batch.struct-as-json")
+  @WithDefault("false")
+  boolean structAsJson();
+
 }

--- a/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/CommonConfig.java
+++ b/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/CommonConfig.java
@@ -21,8 +21,8 @@ public interface CommonConfig {
   @WithDefault("NoBatchSizeWait")
   String batchSizeWaitName();
 
-  @WithName("debezium.sink.batch.struct-as-json")
+  @WithName("debezium.sink.batch.nested-as-json")
   @WithDefault("false")
-  boolean structAsJson();
+  boolean nestedAsJson();
 
 }

--- a/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/DebeziumConfig.java
+++ b/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/DebeziumConfig.java
@@ -6,10 +6,14 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
+import io.smallrye.config.WithParentName;
 
 @ConfigRoot
 @ConfigMapping
 public interface DebeziumConfig {
+
+  @WithParentName
+  CommonConfig common();
 
   @WithName("debezium.format.value")
   @WithDefault("json")

--- a/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/StreamBigqueryChangeConsumer.java
+++ b/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/StreamBigqueryChangeConsumer.java
@@ -230,7 +230,7 @@ public class StreamBigqueryChangeConsumer extends BaseChangeConsumer {
   private Table createTable(TableId tableId, Schema schema, Clustering clustering, TableConstraints tableConstraints) {
 
     StandardTableDefinition.Builder tableDefBuilder = StandardTableDefinition.newBuilder().setSchema(schema);
-    if (!config.common().structAsJson()) {
+    if (!config.common().nestedAsJson()) {
       tableDefBuilder
           .setTimePartitioning(timePartitioning)
           .setClustering(clustering)

--- a/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/StreamBigqueryChangeConsumer.java
+++ b/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/StreamBigqueryChangeConsumer.java
@@ -229,15 +229,15 @@ public class StreamBigqueryChangeConsumer extends BaseChangeConsumer {
   // create table if not exists
   private Table createTable(TableId tableId, Schema schema, Clustering clustering, TableConstraints tableConstraints) {
 
-    StandardTableDefinition tableDefinition =
-        StandardTableDefinition.newBuilder()
-            .setSchema(schema)
-            .setTimePartitioning(timePartitioning)
-            .setClustering(clustering)
-            .setTableConstraints(tableConstraints)
-            .build();
-    TableInfo tableInfo =
-        TableInfo.newBuilder(tableId, tableDefinition).build();
+    StandardTableDefinition.Builder tableDefBuilder = StandardTableDefinition.newBuilder().setSchema(schema);
+    if (!config.common().structAsJson()) {
+      tableDefBuilder
+          .setTimePartitioning(timePartitioning)
+          .setClustering(clustering)
+          .setTableConstraints(tableConstraints);
+    }
+
+    TableInfo tableInfo = TableInfo.newBuilder(tableId, tableDefBuilder.build()).build();
     Table table = bqClient.create(tableInfo);
     LOGGER.warn("Created table {} PK {}", table.getGeneratedId(), tableConstraints.getPrimaryKey());
     // NOTE @TODO ideally we should wait here for streaming cache to update with the new table information 

--- a/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/BatchBigqueryChangeConsumerNestedTest.java
+++ b/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/BatchBigqueryChangeConsumerNestedTest.java
@@ -69,7 +69,7 @@ public class BatchBigqueryChangeConsumerNestedTest extends BaseBigqueryTest {
       Map<String, String> config = new HashMap<>();
       config.put("debezium.sink.type", "bigquerybatch");
       config.put("debezium.transforms", ",");
-      config.put("debezium.sink.batch.struct-as-json", "true");
+      config.put("debezium.sink.batch.nested-as-json", "true");
       return config;
     }
   }

--- a/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/BatchBigqueryChangeConsumerNestedTest.java
+++ b/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/BatchBigqueryChangeConsumerNestedTest.java
@@ -1,0 +1,76 @@
+/*
+ *
+ *  * Copyright memiiso Authors.
+ *  *
+ *  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+
+package io.debezium.server.bigquery;
+
+import com.google.cloud.bigquery.LegacySQLTypeName;
+import io.debezium.server.bigquery.shared.BigQueryGCP;
+import io.debezium.server.bigquery.shared.SourcePostgresqlDB;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.awaitility.Awaitility;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Ismail Simsek
+ */
+@QuarkusTest
+@QuarkusTestResource(value = SourcePostgresqlDB.class, restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = BigQueryGCP.class, restrictToAnnotatedClass = true)
+@TestProfile(BatchBigqueryChangeConsumerNestedTest.TestProfile.class)
+@DisabledIfEnvironmentVariable(named = "GITHUB_ACTIONS", matches = "true")
+public class BatchBigqueryChangeConsumerNestedTest extends BaseBigqueryTest {
+
+  @BeforeAll
+  public static void setup() throws InterruptedException {
+    bqClient = BigQueryGCP.bigQueryClient();
+    dropTables();
+  }
+
+  @Test
+  public void testSimpleUpload() {
+    Awaitility.await().atMost(Duration.ofSeconds(180)).until(() -> {
+      String dest = "testc.inventory.customers";
+      try {
+        prettyPrint(dest);
+        assertTableRowsAboveEqual(dest, 4);
+        Assert.assertEquals(getTableField(dest, "before").getType(), LegacySQLTypeName.JSON);
+        Assert.assertEquals(getTableField(dest, "after").getType(), LegacySQLTypeName.JSON);
+        Assert.assertEquals(getTableField(dest, "source").getType(), LegacySQLTypeName.JSON);
+        Assert.assertEquals(getTableField(dest, "transaction").getType(), LegacySQLTypeName.JSON);
+        Assert.assertEquals(getTableField(dest, "op").getType(), LegacySQLTypeName.STRING);
+        Assert.assertEquals(getTableField(dest, "ts_ms").getType(), LegacySQLTypeName.INTEGER);
+        Assert.assertEquals(getTableField(dest, "ts_ns").getType(), LegacySQLTypeName.INTEGER);
+        return true;
+      } catch (AssertionError | Exception e) {
+        LOGGER.error("Error: {}", e.getMessage());
+        return false;
+      }
+    });
+  }
+
+  public static class TestProfile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      Map<String, String> config = new HashMap<>();
+      config.put("debezium.sink.type", "bigquerybatch");
+      config.put("debezium.transforms", ",");
+      config.put("debezium.sink.batch.struct-as-json", "true");
+      return config;
+    }
+  }
+}

--- a/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/StreamBigqueryChangeConsumerNestedTest.java
+++ b/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/StreamBigqueryChangeConsumerNestedTest.java
@@ -1,0 +1,76 @@
+/*
+ *
+ *  * Copyright memiiso Authors.
+ *  *
+ *  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+
+package io.debezium.server.bigquery;
+
+import com.google.cloud.bigquery.LegacySQLTypeName;
+import io.debezium.server.bigquery.shared.BigQueryDB;
+import io.debezium.server.bigquery.shared.SourcePostgresqlDB;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.awaitility.Awaitility;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Ismail Simsek
+ */
+@QuarkusTest
+@QuarkusTestResource(value = SourcePostgresqlDB.class, restrictToAnnotatedClass = true)
+@TestProfile(StreamBigqueryChangeConsumerNestedTest.TestProfile.class)
+@QuarkusTestResource(value = BigQueryDB.class, restrictToAnnotatedClass = true)
+public class StreamBigqueryChangeConsumerNestedTest extends BaseBigqueryTest {
+
+  @BeforeAll
+  public static void setup() throws InterruptedException {
+    bqClient = BigQueryDB.bigQueryClient();
+//    dropTables();
+    Thread.sleep(5000);
+  }
+
+  @Test
+  public void testSimpleUpload() {
+    Awaitility.await().atMost(Duration.ofSeconds(180)).until(() -> {
+      String dest = "testc.inventory.customers";
+      try {
+        prettyPrint(dest);
+        assertTableRowsAboveEqual(dest, 4);
+        Assert.assertEquals(getTableField(dest, "before").getType(), LegacySQLTypeName.JSON);
+        Assert.assertEquals(getTableField(dest, "after").getType(), LegacySQLTypeName.JSON);
+        Assert.assertEquals(getTableField(dest, "source").getType(), LegacySQLTypeName.JSON);
+        Assert.assertEquals(getTableField(dest, "transaction").getType(), LegacySQLTypeName.JSON);
+        Assert.assertEquals(getTableField(dest, "op").getType(), LegacySQLTypeName.STRING);
+        Assert.assertEquals(getTableField(dest, "ts_ms").getType(), LegacySQLTypeName.INTEGER);
+        Assert.assertEquals(getTableField(dest, "ts_ns").getType(), LegacySQLTypeName.INTEGER);
+        return true;
+      } catch (AssertionError | Exception e) {
+        LOGGER.error("Error: {}", e.getMessage());
+        return false;
+      }
+    });
+  }
+
+
+  public static class TestProfile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      Map<String, String> config = new HashMap<>();
+      config.put("debezium.sink.type", "bigquerystream");
+      config.put("debezium.transforms", ",");
+      config.put("debezium.sink.batch.struct-as-json", "true");
+      return config;
+    }
+  }
+}

--- a/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/StreamBigqueryChangeConsumerNestedTest.java
+++ b/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/StreamBigqueryChangeConsumerNestedTest.java
@@ -69,7 +69,7 @@ public class StreamBigqueryChangeConsumerNestedTest extends BaseBigqueryTest {
       Map<String, String> config = new HashMap<>();
       config.put("debezium.sink.type", "bigquerystream");
       config.put("debezium.transforms", ",");
-      config.put("debezium.sink.batch.struct-as-json", "true");
+      config.put("debezium.sink.batch.nested-as-json", "true");
       return config;
     }
   }


### PR DESCRIPTION
Use boolean config `debezium.sink.batch.nested-as-json` to consume nested data to json fields.

resolves #268
