### PR TITLE
Bump maven dependencies and testcontainers version

### DIFF
--- a/debezium-server-bigquery-sinks/pom.xml
+++ b/debezium-server-bigquery-sinks/pom.xml
@@ -59,6 +59,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>test</scope>

--- a/debezium-server-bigquery-sinks/pom.xml
+++ b/debezium-server-bigquery-sinks/pom.xml
@@ -84,13 +84,11 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>2.0.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>gcloud</artifactId>
-            <version>1.21.4</version>
+            <artifactId>testcontainers-gcloud</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/debezium-server-bigquery-sinks/pom.xml
+++ b/debezium-server-bigquery-sinks/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.21.3</version>
+            <version>2.0.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>3.4.2.Final</version>
+        <version>3.6.0.Final</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>debezium-server-bigquery</artifactId>
@@ -24,8 +24,7 @@
         <!-- NOTE: this is override by release process using CLI argument -->
         <revision>0.0.1-SNAPSHOT</revision>
         <!-- Debezium Version! NOTE: keep same as parent.version above! -->
-        <version.debezium>3.4.2.Final</version.debezium>
-
+        <version.debezium>3.6.0.Final</version.debezium>
         <!-- Instruct the build to use only UTF-8 encoding for source code -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>21</maven.compiler.source>
@@ -33,8 +32,8 @@
         <maven.compiler.release>21</maven.compiler.release>
 
         <skipITs>true</skipITs>
-        <version.gcp.librariesbom>26.78.0</version.gcp.librariesbom>
-        <version.gcp.bigquerybom>2.61.0</version.gcp.bigquerybom>
+        <version.gcp.librariesbom>26.85.0</version.gcp.librariesbom>
+        <version.gcp.bigquerybom>2.68.0</version.gcp.bigquerybom>
         <!-- Plugin versions -->
         <version.assembly.plugin>3.8.0</version.assembly.plugin>
         <version.maven-enforcer-plugin>3.6.2</version.maven-enforcer-plugin>


### PR DESCRIPTION
This pull request updates several dependencies to ensure the project uses the latest versions and remains compatible with upstream changes. The main changes are version bumps for the Debezium parent, Debezium core, Google Cloud Platform (GCP) libraries, and Testcontainers.

Dependency updates:

* Updated the Debezium parent and core version from `3.4.2.Final` to `3.6.0.Final` in `pom.xml` to keep in sync with the latest Debezium release. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L15-R15) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L27-R36)
* Upgraded GCP libraries BOM from `26.78.0` to `26.85.0` and GCP BigQuery BOM from `2.61.0` to `2.68.0` in `pom.xml` for improved compatibility and bug fixes.
* Bumped `testcontainers` dependency from `1.21.3` to `2.0.5` in `debezium-server-bigquery-sinks/pom.xml` to use the latest features and fixes.