### PR TITLE
feat: add safe BigQuery CDC sequencing and append pipelining

### DIFF
--- a/debezium-server-bigquery-dist/src/main/resources/distro/conf/application.properties.example
+++ b/debezium-server-bigquery-dist/src/main/resources/distro/conf/application.properties.example
@@ -43,3 +43,6 @@ quarkus.log.level=INFO
 quarkus.log.console.json=false
 # Ignore messages below warning level from Jetty, because it's a bit verbose
 quarkus.log.category."org.eclipse.jetty".level=WARN
+# Optional BigQuery CDC custom ordering and per-destination append pipelining
+#debezium.sink.bigquerystream.change-sequence.enabled=false
+#debezium.sink.bigquerystream.max-in-flight-appends=1

--- a/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/BaseChangeConsumer.java
+++ b/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/BaseChangeConsumer.java
@@ -46,6 +46,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 /**
@@ -206,7 +207,7 @@ public abstract class BaseChangeConsumer extends io.debezium.server.BaseChangeCo
     }
   }
 
-  private void processTablesInParallel(Map<String, List<ChangeEvent<Object, Object>>> events) {
+  protected void processTablesInParallel(Map<String, List<ChangeEvent<Object, Object>>> events) {
     List<Callable<Void>> tasks = new ArrayList<>();
     for (Map.Entry<String, List<ChangeEvent<Object, Object>>> destinationEvents : events.entrySet()) {
       if (destinationEvents.getKey().startsWith(debeziumConfig.topicHeartbeatPrefix()) && debeziumConfig.topicHeartbeatSkipConsuming()) {
@@ -214,10 +215,12 @@ public abstract class BaseChangeConsumer extends io.debezium.server.BaseChangeCo
       }
 
       tasks.add(() -> {
+        boolean acquired = false;
         try {
           // Acquire a permit from the Semaphore to enforce the concurrency limit.
           LOGGER.trace("Task for destination '{}' waiting for permit. Available: {}", destinationEvents.getKey(), concurrencyLimiter.availablePermits());
           concurrencyLimiter.acquire();
+          acquired = true;
           LOGGER.debug("Task for destination '{}' acquired permit. Starting processing.", destinationEvents.getKey());
 
           this.addToTable(destinationEvents);
@@ -225,40 +228,100 @@ public abstract class BaseChangeConsumer extends io.debezium.server.BaseChangeCo
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt(); // Restore interrupted status
           LOGGER.warn("Task for destination '{}' was interrupted.", destinationEvents.getKey(), e);
-          return null;
+          throw new DebeziumException("Interrupted while acquiring an upload permit for destination '"
+              + destinationEvents.getKey() + "'", e);
         } catch (Exception e) {
           // Log and rethrow. This will be wrapped in an ExecutionException by the Future.
           LOGGER.error("Task for destination '{}' failed.", destinationEvents.getKey(), e);
           throw e;
         } finally {
-          // Always release the permit, even if an exception occurred.
-          concurrencyLimiter.release();
-          LOGGER.trace("Task for destination '{}' released permit. Available: {}", destinationEvents.getKey(), concurrencyLimiter.availablePermits());
+          if (acquired) {
+            concurrencyLimiter.release();
+            LOGGER.trace("Task for destination '{}' released permit. Available: {}", destinationEvents.getKey(), concurrencyLimiter.availablePermits());
+          }
         }
       });
     }
-    // process
     LOGGER.debug("Invoking {} parallel tasks and waiting for completion...", tasks.size());
+    List<Future<Void>> futures = new ArrayList<>(tasks.size());
     try {
-      // Invoke all tasks and wait for them to complete, with a timeout.
-      List<Future<Void>> futures = executor.invokeAll(tasks, concurrentUploadsTimeoutMinutes, TimeUnit.MINUTES);
+      for (Callable<Void> task : tasks) {
+        futures.add(executor.submit(task));
+      }
+    } catch (RuntimeException e) {
+      cancelAndDrain(futures);
+      throw new DebeziumException("Failed to submit parallel destination uploads", e);
+    }
 
-      // Check the status of each task to log any exceptions
-      for (Future<Void> future : futures) {
-        try {
-          // future.get() will throw an exception if the task failed or was cancelled.
+    long deadline = System.nanoTime() + TimeUnit.MINUTES.toNanos(concurrentUploadsTimeoutMinutes);
+    DebeziumException failure = null;
+    boolean interrupted = false;
+    boolean timedOut = false;
+    for (Future<Void> future : futures) {
+      try {
+        long remaining = deadline - System.nanoTime();
+        if (timedOut || remaining <= 0) {
+          if (!timedOut) {
+            timedOut = true;
+            futures.forEach(submitted -> submitted.cancel(true));
+            failure = combineFailures(failure, new DebeziumException("Timed out waiting for parallel destination uploads after "
+                + concurrentUploadsTimeoutMinutes + " minute(s)"));
+          }
           future.get();
-        } catch (CancellationException e) {
-          LOGGER.error("A task was cancelled, likely due to timeout.", e);
-        } catch (ExecutionException e) {
-          // The original exception from the Callable is wrapped in ExecutionException
-          LOGGER.error("A task failed with an exception: {}", e.getCause().getMessage(), e.getCause());
+        } else {
+          future.get(remaining, TimeUnit.NANOSECONDS);
+        }
+      } catch (InterruptedException e) {
+        interrupted = true;
+        Thread.interrupted();
+        futures.forEach(submitted -> submitted.cancel(true));
+        failure = combineFailures(failure, new DebeziumException("Interrupted while waiting for parallel destination uploads", e));
+      } catch (TimeoutException e) {
+        timedOut = true;
+        futures.forEach(submitted -> submitted.cancel(true));
+        failure = combineFailures(failure, new DebeziumException("Timed out waiting for parallel destination uploads after "
+            + concurrentUploadsTimeoutMinutes + " minute(s)", e));
+      } catch (CancellationException e) {
+        failure = combineFailures(failure, new DebeziumException("A parallel destination upload was cancelled", e));
+      } catch (ExecutionException e) {
+        failure = combineFailures(failure, new DebeziumException("A parallel destination upload failed", e.getCause()));
+      }
+    }
+    if (interrupted) {
+      Thread.currentThread().interrupt();
+    }
+    if (failure != null) {
+      throw failure;
+    }
+    LOGGER.debug("All parallel tasks completed successfully.");
+  }
+
+  private static DebeziumException combineFailures(DebeziumException existing, DebeziumException additional) {
+    if (existing == null) {
+      return additional;
+    }
+    existing.addSuppressed(additional);
+    return existing;
+  }
+
+  private static void cancelAndDrain(List<? extends Future<?>> futures) {
+    futures.forEach(future -> future.cancel(true));
+    boolean interrupted = false;
+    for (Future<?> future : futures) {
+      boolean observed = false;
+      while (!observed) {
+        try {
+          future.get();
+          observed = true;
+        } catch (InterruptedException e) {
+          interrupted = true;
+          Thread.interrupted();
+        } catch (CancellationException | ExecutionException e) {
+          observed = true;
         }
       }
-      LOGGER.debug("All parallel tasks have been processed.");
-
-    } catch (InterruptedException e) {
-      LOGGER.warn("Main thread interrupted while waiting for tasks to complete.", e);
+    }
+    if (interrupted) {
       Thread.currentThread().interrupt();
     }
   }

--- a/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/BoundedAppendPipeline.java
+++ b/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/BoundedAppendPipeline.java
@@ -13,6 +13,7 @@ import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
@@ -53,6 +54,11 @@ final class BoundedAppendPipeline {
 
     boolean interrupted = false;
     for (Future<AppendRowsResponse> future : futures) {
+      if (interrupted && !future.isDone()) {
+        failure = combine(failure, new DebeziumException(
+            "A BigQuery append request did not terminate after cancellation"));
+        continue;
+      }
       boolean observed = false;
       while (!observed) {
         try {
@@ -63,9 +69,16 @@ final class BoundedAppendPipeline {
           }
         } catch (InterruptedException e) {
           interrupted = true;
-          // Clear temporarily and retry this future so no append remains unobserved.
-          Thread.interrupted();
           failure = combine(failure, new DebeziumException("Interrupted while waiting for BigQuery append requests", e));
+          cancelOutstanding(futures, failure);
+          if (!future.isDone()) {
+            failure = combine(failure, new DebeziumException(
+                "A BigQuery append request did not terminate after cancellation"));
+          }
+          observed = true;
+        } catch (CancellationException e) {
+          observed = true;
+          failure = combine(failure, new DebeziumException("A BigQuery append request was cancelled", e));
         } catch (ExecutionException | RuntimeException e) {
           observed = true;
           failure = combine(failure, StreamDataWriter.createDebeziumExceptionFromException(e));
@@ -77,6 +90,18 @@ final class BoundedAppendPipeline {
     }
     if (failure != null) {
       throw failure;
+    }
+  }
+
+  private static void cancelOutstanding(List<? extends Future<?>> futures, DebeziumException failure) {
+    for (Future<?> future : futures) {
+      if (!future.isDone()) {
+        try {
+          future.cancel(true);
+        } catch (RuntimeException e) {
+          failure.addSuppressed(new DebeziumException("Failed to cancel a BigQuery append request", e));
+        }
+      }
     }
   }
 

--- a/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/BoundedAppendPipeline.java
+++ b/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/BoundedAppendPipeline.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright memiiso Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.server.bigquery;
+
+import com.google.cloud.bigquery.storage.v1.AppendRowsResponse;
+import io.debezium.DebeziumException;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+/** Submits a bounded number of balanced append requests and observes every result. */
+final class BoundedAppendPipeline {
+  @FunctionalInterface
+  interface Appender {
+    Future<AppendRowsResponse> append(JSONArray rows) throws Exception;
+  }
+
+  private BoundedAppendPipeline() {
+  }
+
+  static void append(List<JSONObject> rows, int maxInFlight, Appender appender) {
+    if (rows.isEmpty()) {
+      return;
+    }
+    int appendCount = Math.min(maxInFlight, rows.size());
+    List<Future<AppendRowsResponse>> futures = new ArrayList<>(appendCount);
+    DebeziumException failure = null;
+
+    int baseSize = rows.size() / appendCount;
+    int largerChunks = rows.size() % appendCount;
+    int offset = 0;
+    for (int chunk = 0; chunk < appendCount; chunk++) {
+      int chunkSize = baseSize + (chunk < largerChunks ? 1 : 0);
+      JSONArray payload = new JSONArray();
+      for (int i = 0; i < chunkSize; i++) {
+        payload.put(rows.get(offset++));
+      }
+      try {
+        futures.add(appender.append(payload));
+      } catch (Exception e) {
+        failure = combine(failure, new DebeziumException("Failed to submit BigQuery append request", e));
+        break;
+      }
+    }
+
+    boolean interrupted = false;
+    for (Future<AppendRowsResponse> future : futures) {
+      boolean observed = false;
+      while (!observed) {
+        try {
+          AppendRowsResponse response = future.get();
+          observed = true;
+          if (response.hasError()) {
+            failure = combine(failure, StreamDataWriter.createDebeziumExceptionFromResponseError(response));
+          }
+        } catch (InterruptedException e) {
+          interrupted = true;
+          // Clear temporarily and retry this future so no append remains unobserved.
+          Thread.interrupted();
+          failure = combine(failure, new DebeziumException("Interrupted while waiting for BigQuery append requests", e));
+        } catch (ExecutionException | RuntimeException e) {
+          observed = true;
+          failure = combine(failure, StreamDataWriter.createDebeziumExceptionFromException(e));
+        }
+      }
+    }
+    if (interrupted) {
+      Thread.currentThread().interrupt();
+    }
+    if (failure != null) {
+      throw failure;
+    }
+  }
+
+  private static DebeziumException combine(DebeziumException existing, DebeziumException additional) {
+    if (existing == null) {
+      return additional;
+    }
+    existing.addSuppressed(additional);
+    return existing;
+  }
+}

--- a/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/ChangeSequenceNumber.java
+++ b/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/ChangeSequenceNumber.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright memiiso Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.server.bigquery;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.debezium.DebeziumException;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** A complete Debezium source coordinate formatted for BigQuery custom CDC ordering. */
+public final class ChangeSequenceNumber implements Comparable<ChangeSequenceNumber> {
+  public static final String PSEUDO_COLUMN = "_CHANGE_SEQUENCE_NUMBER";
+  private static final List<String> NUMERIC_FIELDS = List.of("__source_ts_ns", "__source_pos", "__source_row");
+  private static final Pattern TRAILING_NUMBER = Pattern.compile("(\\d+)$");
+  private static final BigInteger MAX_SECTION_VALUE = BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE);
+
+  private final List<BigInteger> sections;
+
+  private ChangeSequenceNumber(List<BigInteger> sections) {
+    this.sections = List.copyOf(sections);
+  }
+
+  public static ChangeSequenceNumber from(JsonNode value) {
+    BigInteger timestamp = numericField(value, NUMERIC_FIELDS.get(0));
+    JsonNode fileNode = requiredField(value, "__source_file");
+    if (!fileNode.isTextual() || fileNode.textValue().isBlank()) {
+      throw invalid("__source_file", fileNode, "must be a non-blank string ending in a numeric component");
+    }
+    Matcher matcher = TRAILING_NUMBER.matcher(fileNode.textValue());
+    if (!matcher.find()) {
+      throw invalid("__source_file", fileNode, "must end in a numeric component (for example mysql-bin.001234)");
+    }
+    BigInteger fileIndex = bounded("__source_file", matcher.group(1), new BigInteger(matcher.group(1)));
+    BigInteger position = numericField(value, NUMERIC_FIELDS.get(1));
+    BigInteger row = numericField(value, NUMERIC_FIELDS.get(2));
+    return new ChangeSequenceNumber(List.of(timestamp, fileIndex, position, row));
+  }
+
+  private static BigInteger numericField(JsonNode value, String field) {
+    JsonNode node = requiredField(value, field);
+    if (!node.isIntegralNumber() && !node.isTextual()) {
+      throw invalid(field, node, "must be a non-negative integer");
+    }
+    try {
+      String raw = node.isIntegralNumber() ? node.bigIntegerValue().toString() : node.textValue();
+      if (raw == null || !raw.matches("\\d+")) {
+        throw new NumberFormatException();
+      }
+      return bounded(field, raw, new BigInteger(raw));
+    } catch (NumberFormatException e) {
+      throw invalid(field, node, "must be a non-negative integer");
+    }
+  }
+
+  private static BigInteger bounded(String field, String raw, BigInteger number) {
+    if (number.signum() < 0 || number.compareTo(MAX_SECTION_VALUE) > 0) {
+      throw new DebeziumException("Cannot construct BigQuery change sequence: field '" + field
+          + "' value '" + raw + "' is outside the unsigned 64-bit range");
+    }
+    return number;
+  }
+
+  private static JsonNode requiredField(JsonNode value, String field) {
+    if (value == null || value.isNull() || !value.hasNonNull(field)) {
+      throw new DebeziumException("Cannot construct BigQuery change sequence: required Debezium unwrap field '"
+          + field + "' is missing; configure unwrap add.fields with source.ts_ns,source.file,source.pos,source.row");
+    }
+    return value.get(field);
+  }
+
+  private static DebeziumException invalid(String field, JsonNode value, String expectation) {
+    return new DebeziumException("Cannot construct BigQuery change sequence: field '" + field + "' value "
+        + String.valueOf(value) + " " + expectation);
+  }
+
+  @Override
+  public int compareTo(ChangeSequenceNumber other) {
+    for (int i = 0; i < sections.size(); i++) {
+      int result = sections.get(i).compareTo(other.sections.get(i));
+      if (result != 0) {
+        return result;
+      }
+    }
+    return 0;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%016X/%016X/%016X/%016X",
+        sections.get(0), sections.get(1), sections.get(2), sections.get(3));
+  }
+}

--- a/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/ChangeSequenceNumber.java
+++ b/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/ChangeSequenceNumber.java
@@ -17,9 +17,9 @@ import java.util.regex.Pattern;
 /** A complete Debezium source coordinate formatted for BigQuery custom CDC ordering. */
 public final class ChangeSequenceNumber implements Comparable<ChangeSequenceNumber> {
   public static final String PSEUDO_COLUMN = "_CHANGE_SEQUENCE_NUMBER";
-  private static final List<String> NUMERIC_FIELDS = List.of("__source_ts_ns", "__source_pos", "__source_row");
   private static final Pattern TRAILING_NUMBER = Pattern.compile("(\\d+)$");
   private static final BigInteger MAX_SECTION_VALUE = BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE);
+  private static final BigInteger ZERO = BigInteger.ZERO;
 
   private final List<BigInteger> sections;
 
@@ -28,7 +28,19 @@ public final class ChangeSequenceNumber implements Comparable<ChangeSequenceNumb
   }
 
   public static ChangeSequenceNumber from(JsonNode value) {
-    BigInteger timestamp = numericField(value, NUMERIC_FIELDS.get(0));
+    BigInteger timestamp = numericField(value, "__source_ts_ns");
+    if (hasValue(value, "__source_file")) {
+      return fromMySql(value, timestamp);
+    }
+    if (hasValue(value, "__source_lsn")) {
+      return fromPostgres(value, timestamp);
+    }
+    throw new DebeziumException("Cannot construct BigQuery change sequence: no supported source coordinates found; "
+        + "configure unwrap add.fields with source.ts_ns,source.file,source.pos,source.row for MySQL or "
+        + "source.ts_ns,source.lsn,source.txId for PostgreSQL");
+  }
+
+  private static ChangeSequenceNumber fromMySql(JsonNode value, BigInteger timestamp) {
     JsonNode fileNode = requiredField(value, "__source_file");
     if (!fileNode.isTextual() || fileNode.textValue().isBlank()) {
       throw invalid("__source_file", fileNode, "must be a non-blank string ending in a numeric component");
@@ -38,9 +50,19 @@ public final class ChangeSequenceNumber implements Comparable<ChangeSequenceNumb
       throw invalid("__source_file", fileNode, "must end in a numeric component (for example mysql-bin.001234)");
     }
     BigInteger fileIndex = bounded("__source_file", matcher.group(1), new BigInteger(matcher.group(1)));
-    BigInteger position = numericField(value, NUMERIC_FIELDS.get(1));
-    BigInteger row = numericField(value, NUMERIC_FIELDS.get(2));
+    BigInteger position = numericField(value, "__source_pos");
+    BigInteger row = numericField(value, "__source_row");
     return new ChangeSequenceNumber(List.of(timestamp, fileIndex, position, row));
+  }
+
+  private static ChangeSequenceNumber fromPostgres(JsonNode value, BigInteger timestamp) {
+    BigInteger lsn = numericField(value, "__source_lsn");
+    BigInteger transactionId = numericField(value, "__source_txId");
+    return new ChangeSequenceNumber(List.of(timestamp, lsn, transactionId, ZERO));
+  }
+
+  private static boolean hasValue(JsonNode value, String field) {
+    return value != null && !value.isNull() && value.hasNonNull(field);
   }
 
   private static BigInteger numericField(JsonNode value, String field) {
@@ -70,7 +92,7 @@ public final class ChangeSequenceNumber implements Comparable<ChangeSequenceNumb
   private static JsonNode requiredField(JsonNode value, String field) {
     if (value == null || value.isNull() || !value.hasNonNull(field)) {
       throw new DebeziumException("Cannot construct BigQuery change sequence: required Debezium unwrap field '"
-          + field + "' is missing; configure unwrap add.fields with source.ts_ns,source.file,source.pos,source.row");
+          + field + "' is missing; configure all sequence fields documented for the source connector");
     }
     return value.get(field);
   }

--- a/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/ChangeSequenceNumber.java
+++ b/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/ChangeSequenceNumber.java
@@ -18,8 +18,8 @@ import java.util.regex.Pattern;
 public final class ChangeSequenceNumber implements Comparable<ChangeSequenceNumber> {
   public static final String PSEUDO_COLUMN = "_CHANGE_SEQUENCE_NUMBER";
   private static final Pattern TRAILING_NUMBER = Pattern.compile("(\\d+)$");
+  private static final Pattern POSTGRES_LSN = Pattern.compile("^([0-9A-Fa-f]{1,8})/([0-9A-Fa-f]{1,8})$");
   private static final BigInteger MAX_SECTION_VALUE = BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE);
-  private static final BigInteger ZERO = BigInteger.ZERO;
 
   private final List<BigInteger> sections;
 
@@ -37,7 +37,7 @@ public final class ChangeSequenceNumber implements Comparable<ChangeSequenceNumb
     }
     throw new DebeziumException("Cannot construct BigQuery change sequence: no supported source coordinates found; "
         + "configure unwrap add.fields with source.ts_ns,source.file,source.pos,source.row for MySQL or "
-        + "source.ts_ns,source.lsn,source.txId for PostgreSQL");
+        + "source.ts_ns,source.lsn,source.txId,transaction.total_order for PostgreSQL");
   }
 
   private static ChangeSequenceNumber fromMySql(JsonNode value, BigInteger timestamp) {
@@ -56,9 +56,30 @@ public final class ChangeSequenceNumber implements Comparable<ChangeSequenceNumb
   }
 
   private static ChangeSequenceNumber fromPostgres(JsonNode value, BigInteger timestamp) {
-    BigInteger lsn = numericField(value, "__source_lsn");
+    BigInteger lsn = postgresLsnField(value, "__source_lsn");
     BigInteger transactionId = numericField(value, "__source_txId");
-    return new ChangeSequenceNumber(List.of(timestamp, lsn, transactionId, ZERO));
+    BigInteger transactionOrder = numericField(value, "__transaction_total_order");
+    return new ChangeSequenceNumber(List.of(timestamp, lsn, transactionId, transactionOrder));
+  }
+
+  private static BigInteger postgresLsnField(JsonNode value, String field) {
+    JsonNode node = requiredField(value, field);
+    if (node.isIntegralNumber()) {
+      return numericField(value, field);
+    }
+    if (node.isTextual()) {
+      String raw = node.textValue();
+      Matcher matcher = POSTGRES_LSN.matcher(raw);
+      if (matcher.matches()) {
+        BigInteger high = new BigInteger(matcher.group(1), 16);
+        BigInteger low = new BigInteger(matcher.group(2), 16);
+        return bounded(field, raw, high.shiftLeft(32).add(low));
+      }
+      if (raw.matches("\\d+")) {
+        return bounded(field, raw, new BigInteger(raw));
+      }
+    }
+    throw invalid(field, node, "must be a non-negative decimal integer or PostgreSQL hexadecimal LSN (for example 0/16B3748)");
   }
 
   private static boolean hasValue(JsonNode value, String field) {

--- a/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/StorageWriteSchemaConverter.java
+++ b/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/StorageWriteSchemaConverter.java
@@ -12,6 +12,10 @@ import java.util.stream.Collectors;
 public class StorageWriteSchemaConverter {
 
   public static TableSchema toStorageTableSchema(Schema schema, boolean doUpsert) {
+    return toStorageTableSchema(schema, doUpsert, false);
+  }
+
+  public static TableSchema toStorageTableSchema(Schema schema, boolean doUpsert, boolean changeSequenceEnabled) {
     TableSchema.Builder builder = TableSchema.newBuilder();
     for (Field field : schema.getFields()) {
       builder.addFields(convertField(field));
@@ -22,6 +26,13 @@ public class StorageWriteSchemaConverter {
           .setType(TableFieldSchema.Type.STRING)
           .setMode(TableFieldSchema.Mode.NULLABLE)
           .build());
+      if (changeSequenceEnabled) {
+        builder.addFields(TableFieldSchema.newBuilder()
+            .setName(ChangeSequenceNumber.PSEUDO_COLUMN)
+            .setType(TableFieldSchema.Type.STRING)
+            .setMode(TableFieldSchema.Mode.NULLABLE)
+            .build());
+      }
     }
     return builder.build();
   }

--- a/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/StreamBigqueryChangeConsumer.java
+++ b/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/StreamBigqueryChangeConsumer.java
@@ -101,6 +101,10 @@ public class StreamBigqueryChangeConsumer extends BaseChangeConsumer {
   }
 
   public void initialize() throws InterruptedException {
+    if (config.maxInFlightAppends() < 1) {
+      throw new DebeziumException("debezium.sink.bigquerystream.max-in-flight-appends must be at least 1, but was "
+          + config.maxInFlightAppends());
+    }
     super.initialize();
 
     bqClient = ConsumerUtil.bigqueryClient(config.isBigqueryDevEmulator(), config.gcpProject(), config.bqDataset(), config.credentialsFile(), config.bqLocation(), config.bigQueryCustomHost());
@@ -145,7 +149,9 @@ public class StreamBigqueryChangeConsumer extends BaseChangeConsumer {
         TableName tableName = TableName.of(table.getTableId().getProject(), table.getTableId().getDataset(), table.getTableId().getTable());
         streamOrTableName = tableName.toString();
       }
-      TableSchema storageTableSchema = StorageWriteSchemaConverter.toStorageTableSchema(table.getDefinition().getSchema(), doUpsert(table));
+      boolean doUpsert = doUpsert(table);
+      TableSchema storageTableSchema = StorageWriteSchemaConverter.toStorageTableSchema(
+          table.getDefinition().getSchema(), doUpsert, doUpsert && config.changeSequenceEnabled());
       StreamDataWriter writer = new StreamDataWriter(
           streamOrTableName,
           bigQueryWriteClient,
@@ -190,12 +196,21 @@ public class StreamBigqueryChangeConsumer extends BaseChangeConsumer {
         data = deduplicateBatch(data);
       }
       // add data to JSONArray
-      JSONArray jsonArr = new JSONArray();
+      List<JSONObject> rows = new ArrayList<>(data.size());
       data.forEach(e -> {
-        JSONObject val = e.convert(table.getDefinition().getSchema(), doUpsert, config.upsertKeepDeletes());
-        jsonArr.put(val);
+        JSONObject val = e instanceof StreamRecordConverter streamRecord
+            ? streamRecord.convert(table.getDefinition().getSchema(), doUpsert, config.upsertKeepDeletes(), config.changeSequenceEnabled())
+            : e.convert(table.getDefinition().getSchema(), doUpsert, config.upsertKeepDeletes());
+        if (doUpsert && config.changeSequenceEnabled() && !val.has(ChangeSequenceNumber.PSEUDO_COLUMN)) {
+          val.put(ChangeSequenceNumber.PSEUDO_COLUMN, ChangeSequenceNumber.from(e.value()).toString());
+        }
+        rows.add(val);
       });
-      writer.appendSync(jsonArr);
+      if (config.maxInFlightAppends() == 1) {
+        writer.appendSync(new JSONArray(rows));
+      } else {
+        BoundedAppendPipeline.append(rows, config.maxInFlightAppends(), writer::appendAsync);
+      }
     } catch (DescriptorValidationException | IOException e) {
       throw new DebeziumException("Failed to append data to stream " + writer.streamWriter.getStreamName(), e);
     }
@@ -211,7 +226,10 @@ public class StreamBigqueryChangeConsumer extends BaseChangeConsumer {
     events.forEach(e ->
         // deduplicate using key(PK)
         deduplicatedEvents.merge(e.key(), e, (oldValue, newValue) -> {
-          if (this.compareByTsThenOp(oldValue.value(), newValue.value()) <= 0) {
+          int comparison = config.changeSequenceEnabled()
+              ? ChangeSequenceNumber.from(oldValue.value()).compareTo(ChangeSequenceNumber.from(newValue.value()))
+              : this.compareByTsThenOp(oldValue.value(), newValue.value());
+          if (comparison <= 0) {
             return newValue;
           } else {
             return oldValue;

--- a/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/StreamBigqueryChangeConsumer.java
+++ b/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/StreamBigqueryChangeConsumer.java
@@ -209,7 +209,7 @@ public class StreamBigqueryChangeConsumer extends BaseChangeConsumer {
       if (config.maxInFlightAppends() == 1) {
         writer.appendSync(new JSONArray(rows));
       } else {
-        BoundedAppendPipeline.append(rows, config.maxInFlightAppends(), writer::appendAsync);
+        writer.appendPipelined(rows, config.maxInFlightAppends());
       }
     } catch (DescriptorValidationException | IOException e) {
       throw new DebeziumException("Failed to append data to stream " + writer.streamWriter.getStreamName(), e);

--- a/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/StreamConsumerConfig.java
+++ b/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/StreamConsumerConfig.java
@@ -72,6 +72,14 @@ public interface StreamConsumerConfig {
   @WithDefault("true")
   boolean upsertKeepDeletes();
 
+  @WithName("debezium.sink.bigquerystream.change-sequence.enabled")
+  @WithDefault("false")
+  boolean changeSequenceEnabled();
+
+  @WithName("debezium.sink.bigquerystream.max-in-flight-appends")
+  @WithDefault("1")
+  int maxInFlightAppends();
+
   @WithName("debezium.sink.bigquerystream.upsert-dedup-column")
   Optional<String> sourceTsColumn();
 

--- a/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/StreamDataWriter.java
+++ b/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/StreamDataWriter.java
@@ -1,6 +1,5 @@
 package io.debezium.server.bigquery;
 
-import com.google.api.core.ApiFuture;
 import com.google.api.gax.core.FixedExecutorProvider;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.cloud.bigquery.BigQueryException;
@@ -22,6 +21,7 @@ import org.threeten.bp.Duration;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -102,23 +102,29 @@ public class StreamDataWriter {
 
   public void appendSync(JSONArray data) throws DescriptorValidationException, IOException {
     try {
-      synchronized (this.lock) {
-        if (!streamWriter.isUserClosed() && streamWriter.isClosed() && recreateCount.getAndIncrement() < MAX_RECREATE_COUNT) {
-          streamWriter = createStreamWriter();
-        }
-      }
-
-      ApiFuture<AppendRowsResponse> future = streamWriter.append(data);
+      Future<AppendRowsResponse> future = appendAsync(data);
       AppendRowsResponse response = future.get();
       if (response.hasError()) {
         throw createDebeziumExceptionFromResponseError(response);
       }
-    } catch (InterruptedException | ExecutionException | Exceptions.AppendSerializationError e) {
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw createDebeziumExceptionFromException(e);
+    } catch (ExecutionException | Exceptions.AppendSerializationError e) {
       throw createDebeziumExceptionFromException(e);
     }
   }
 
-  private DebeziumException createDebeziumExceptionFromResponseError(AppendRowsResponse response) {
+  Future<AppendRowsResponse> appendAsync(JSONArray data) throws DescriptorValidationException, IOException, InterruptedException {
+    synchronized (this.lock) {
+      if (!streamWriter.isUserClosed() && streamWriter.isClosed() && recreateCount.getAndIncrement() < MAX_RECREATE_COUNT) {
+        streamWriter = createStreamWriter();
+      }
+    }
+    return streamWriter.append(data);
+  }
+
+  static DebeziumException createDebeziumExceptionFromResponseError(AppendRowsResponse response) {
     StringBuilder errorMessageBuilder = new StringBuilder("Failed to append data to stream.\n");
 
     Status error = response.getError();
@@ -137,7 +143,7 @@ public class StreamDataWriter {
     return new DebeziumException(errorMessageBuilder.toString());
   }
 
-  private DebeziumException createDebeziumExceptionFromException(Exception e) {
+  static DebeziumException createDebeziumExceptionFromException(Exception e) {
     StringBuilder exceptionMessage = new StringBuilder("Failed to append data to stream due to an exception.\n");
     exceptionMessage.append("Exception: ").append(e.getClass().getName()).append("\n");
     exceptionMessage.append("Message: ").append(e.getMessage()).append("\n");

--- a/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/StreamDataWriter.java
+++ b/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/StreamDataWriter.java
@@ -14,6 +14,7 @@ import com.google.protobuf.Descriptors.DescriptorValidationException;
 import com.google.rpc.Status;
 import io.debezium.DebeziumException;
 import org.json.JSONArray;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.threeten.bp.Duration;
@@ -107,7 +108,7 @@ public class StreamDataWriter {
       if (response.hasError()) {
         throw createDebeziumExceptionFromResponseError(response);
       }
-      recreateCount.set(0);
+      resetRecreateCount();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw createDebeziumExceptionFromException(e);
@@ -123,6 +124,15 @@ public class StreamDataWriter {
       }
     }
     return streamWriter.append(data);
+  }
+
+  void appendPipelined(List<JSONObject> rows, int maxInFlight) {
+    BoundedAppendPipeline.append(rows, maxInFlight, this::appendAsync);
+    resetRecreateCount();
+  }
+
+  void resetRecreateCount() {
+    recreateCount.set(0);
   }
 
   static DebeziumException createDebeziumExceptionFromResponseError(AppendRowsResponse response) {

--- a/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/StreamRecordConverter.java
+++ b/debezium-server-bigquery-sinks/src/main/java/io/debezium/server/bigquery/StreamRecordConverter.java
@@ -87,4 +87,14 @@ public class StreamRecordConverter extends BaseRecordConverter {
     return new JSONObject(jsonMap);
   }
 
+  /** Converts a CDC row and adds the custom ordering pseudocolumn when requested. */
+  public JSONObject convert(Schema schema, boolean upsert, boolean upsertKeepDeletes, boolean changeSequenceEnabled)
+      throws DebeziumException {
+    JSONObject converted = convert(schema, upsert, upsertKeepDeletes);
+    if (upsert && changeSequenceEnabled) {
+      converted.put(ChangeSequenceNumber.PSEUDO_COLUMN, ChangeSequenceNumber.from(value).toString());
+    }
+    return converted;
+  }
+
 }

--- a/debezium-server-bigquery-sinks/src/main/resources/conf/application.properties.example
+++ b/debezium-server-bigquery-sinks/src/main/resources/conf/application.properties.example
@@ -42,3 +42,6 @@ quarkus.log.level=INFO
 quarkus.log.console.json=false
 # Ignore messages below warning level from Jetty, because it's a bit verbose
 quarkus.log.category."org.eclipse.jetty".level=WARN
+# Optional BigQuery CDC custom ordering and per-destination append pipelining
+#debezium.sink.bigquerystream.change-sequence.enabled=false
+#debezium.sink.bigquerystream.max-in-flight-appends=1

--- a/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/BaseChangeConsumerParallelTest.java
+++ b/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/BaseChangeConsumerParallelTest.java
@@ -1,0 +1,169 @@
+package io.debezium.server.bigquery;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.debezium.DebeziumException;
+import io.debezium.engine.ChangeEvent;
+import io.debezium.engine.DebeziumEngine;
+import io.debezium.server.bigquery.batchsizewait.BatchSizeWait;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BaseChangeConsumerParallelTest {
+  private TestConsumer consumer;
+
+  @AfterEach
+  void closeExecutor() {
+    if (consumer != null) {
+      consumer.shutdownExecutors();
+    }
+  }
+
+  @Test
+  void destinationFailurePreventsAllCommitterCalls() throws Exception {
+    consumer = configuredConsumer(2, 1);
+    consumer.failedDestination = "bad";
+    List<ChangeEvent<Object, Object>> records = List.of(event("good"), event("bad"));
+    DebeziumEngine.RecordCommitter<ChangeEvent<Object, Object>> committer = mock(DebeziumEngine.RecordCommitter.class);
+
+    assertThrows(DebeziumException.class, () -> consumer.handleBatch(records, committer));
+    verify(committer, never()).markProcessed(org.mockito.ArgumentMatchers.any());
+    verify(committer, never()).markBatchFinished();
+  }
+
+  @Test
+  void timeoutPreventsOffsetAdvancement() throws Exception {
+    consumer = configuredConsumer(2, 0);
+    consumer.blockUploads = true;
+    List<ChangeEvent<Object, Object>> records = List.of(event("slow"));
+    DebeziumEngine.RecordCommitter<ChangeEvent<Object, Object>> committer = mock(DebeziumEngine.RecordCommitter.class);
+
+    assertThrows(DebeziumException.class, () -> consumer.handleBatch(records, committer));
+    verify(committer, never()).markProcessed(org.mockito.ArgumentMatchers.any());
+    verify(committer, never()).markBatchFinished();
+  }
+
+  @Test
+  void successfulDestinationsCommitEveryRecordAndFinishOnce() throws Exception {
+    consumer = configuredConsumer(2, 1);
+    List<ChangeEvent<Object, Object>> records = List.of(event("one"), event("two"));
+    DebeziumEngine.RecordCommitter<ChangeEvent<Object, Object>> committer = mock(DebeziumEngine.RecordCommitter.class);
+
+    consumer.handleBatch(records, committer);
+    verify(committer, times(2)).markProcessed(org.mockito.ArgumentMatchers.any());
+    verify(committer, times(1)).markBatchFinished();
+  }
+
+  @Test
+  void interruptedSemaphoreAcquisitionDoesNotReleaseUnacquiredPermit() throws Exception {
+    consumer = configuredConsumer(2, 1);
+    ObservedSemaphore semaphore = new ObservedSemaphore();
+    setField(consumer, "concurrencyLimiter", semaphore);
+    AtomicReference<Throwable> thrown = new AtomicReference<>();
+    AtomicBoolean interruptPreserved = new AtomicBoolean();
+    Thread caller = new Thread(() -> {
+      try {
+        consumer.processTablesInParallel(Map.of("blocked", List.of(event("blocked"))));
+      } catch (Throwable e) {
+        thrown.set(e);
+        interruptPreserved.set(Thread.currentThread().isInterrupted());
+      }
+    });
+    caller.start();
+    semaphore.acquisitionAttempted.await();
+    caller.interrupt();
+    caller.join(5000);
+
+    assertFalse(caller.isAlive());
+    assertNotNull(thrown.get());
+    assertTrue(thrown.get() instanceof DebeziumException);
+    assertTrue(interruptPreserved.get());
+    assertEquals(0, semaphore.availablePermits());
+  }
+
+  private static TestConsumer configuredConsumer(int concurrency, int timeoutMinutes) throws Exception {
+    TestConsumer result = new TestConsumer();
+    result.debeziumConfig = mock(DebeziumConfig.class);
+    when(result.debeziumConfig.topicHeartbeatPrefix()).thenReturn("__heartbeat");
+    when(result.debeziumConfig.topicHeartbeatSkipConsuming()).thenReturn(false);
+    result.batchSizeWait = mock(BatchSizeWait.class);
+    setField(result, "numConcurrentUploads", concurrency);
+    setField(result, "concurrentUploadsTimeoutMinutes", timeoutMinutes);
+    setField(result, "concurrencyLimiter", new Semaphore(concurrency));
+    return result;
+  }
+
+  private static void setField(Object target, String name, Object value) throws Exception {
+    Field field = BaseChangeConsumer.class.getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static ChangeEvent<Object, Object> event(String destination) {
+    ChangeEvent<Object, Object> event = mock(ChangeEvent.class);
+    when(event.destination()).thenReturn(destination);
+    return event;
+  }
+
+  private static class TestConsumer extends BaseChangeConsumer {
+    private String failedDestination;
+    private boolean blockUploads;
+    private final CountDownLatch blocker = new CountDownLatch(1);
+
+    @Override
+    public long uploadDestination(String destination, List<RecordConverter> data) {
+      if (destination.equals(failedDestination)) {
+        throw new DebeziumException("deliberate failure");
+      }
+      if (blockUploads) {
+        try {
+          blocker.await();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new DebeziumException("cancelled upload", e);
+        }
+      }
+      return data.size();
+    }
+
+    @Override
+    public RecordConverter eventAsRecordConverter(ChangeEvent<Object, Object> event) {
+      RecordConverter converter = mock(RecordConverter.class);
+      when(converter.valueSchema()).thenReturn(JsonNodeFactory.instance.objectNode());
+      return converter;
+    }
+  }
+
+  private static class ObservedSemaphore extends Semaphore {
+    private final CountDownLatch acquisitionAttempted = new CountDownLatch(1);
+
+    private ObservedSemaphore() {
+      super(0);
+    }
+
+    @Override
+    public void acquire() throws InterruptedException {
+      acquisitionAttempted.countDown();
+      super.acquire();
+    }
+  }
+}

--- a/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/BoundedAppendPipelineTest.java
+++ b/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/BoundedAppendPipelineTest.java
@@ -1,0 +1,97 @@
+package io.debezium.server.bigquery;
+
+import com.google.cloud.bigquery.storage.v1.AppendRowsResponse;
+import com.google.rpc.Status;
+import io.debezium.DebeziumException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BoundedAppendPipelineTest {
+  @Test
+  void oneAppendWaitsForCompletion() throws Exception {
+    assertBoundAndReorderedCompletion(1);
+  }
+
+  @Test
+  void configuredBoundsAndReorderedCompletionsAreSafe() throws Exception {
+    assertBoundAndReorderedCompletion(2);
+    assertBoundAndReorderedCompletion(4);
+    assertBoundAndReorderedCompletion(8);
+  }
+
+  @Test
+  void oneFailedResponseFailsAfterOtherFuturesSucceed() throws Exception {
+    List<CompletableFuture<AppendRowsResponse>> completions = new CopyOnWriteArrayList<>();
+    CountDownLatch submitted = new CountDownLatch(2);
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      Future<?> result = executor.submit(() -> BoundedAppendPipeline.append(rows(4), 2, payload -> {
+        CompletableFuture<AppendRowsResponse> future = new CompletableFuture<>();
+        completions.add(future);
+        submitted.countDown();
+        return future;
+      }));
+      submitted.await();
+      completions.get(0).complete(AppendRowsResponse.newBuilder()
+          .setError(Status.newBuilder().setCode(3).setMessage("bad append")).build());
+      completions.get(1).complete(AppendRowsResponse.getDefaultInstance());
+      ExecutionException error = assertThrows(ExecutionException.class, result::get);
+      assertTrue(error.getCause() instanceof DebeziumException);
+      assertTrue(error.getCause().getMessage().contains("bad append"));
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  private static void assertBoundAndReorderedCompletion(int bound) throws Exception {
+    int expected = Math.min(bound, 16);
+    List<CompletableFuture<AppendRowsResponse>> completions = new CopyOnWriteArrayList<>();
+    AtomicInteger outstanding = new AtomicInteger();
+    AtomicInteger maximum = new AtomicInteger();
+    CountDownLatch submitted = new CountDownLatch(expected);
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      Future<?> result = executor.submit(() -> BoundedAppendPipeline.append(rows(16), bound, payload -> {
+        CompletableFuture<AppendRowsResponse> future = new CompletableFuture<>();
+        completions.add(future);
+        maximum.accumulateAndGet(outstanding.incrementAndGet(), Math::max);
+        future.whenComplete((ignored, error) -> outstanding.decrementAndGet());
+        submitted.countDown();
+        return future;
+      }));
+      submitted.await();
+      assertEquals(expected, completions.size());
+      assertEquals(expected, maximum.get());
+      for (int i = completions.size() - 1; i >= 0; i--) {
+        completions.get(i).complete(AppendRowsResponse.getDefaultInstance());
+      }
+      result.get();
+      assertEquals(0, outstanding.get());
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  private static List<JSONObject> rows(int count) {
+    List<JSONObject> rows = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      rows.add(new JSONObject().put("id", i));
+    }
+    return rows;
+  }
+}

--- a/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/BoundedAppendPipelineTest.java
+++ b/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/BoundedAppendPipelineTest.java
@@ -15,7 +15,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -58,6 +62,37 @@ class BoundedAppendPipelineTest {
     }
   }
 
+  @Test
+  void interruptionCancelsOutstandingAppendsWithoutWaitingIndefinitely() throws Exception {
+    NeverCompletingFuture stuck = new NeverCompletingFuture();
+    CompletableFuture<AppendRowsResponse> other = new CompletableFuture<>();
+    AtomicInteger submitted = new AtomicInteger();
+    AtomicReference<Throwable> thrown = new AtomicReference<>();
+    AtomicBoolean interruptPreserved = new AtomicBoolean();
+    CountDownLatch finished = new CountDownLatch(1);
+    Thread caller = new Thread(() -> {
+      try {
+        BoundedAppendPipeline.append(rows(2), 2,
+            payload -> submitted.getAndIncrement() == 0 ? stuck : other);
+      } catch (Throwable e) {
+        thrown.set(e);
+        interruptPreserved.set(Thread.currentThread().isInterrupted());
+      } finally {
+        finished.countDown();
+      }
+    });
+
+    caller.start();
+    stuck.getStarted.await();
+    caller.interrupt();
+
+    assertTrue(finished.await(5, TimeUnit.SECONDS));
+    assertTrue(thrown.get() instanceof DebeziumException);
+    assertTrue(interruptPreserved.get());
+    assertTrue(stuck.cancelAttempted.get());
+    assertTrue(other.isCancelled());
+  }
+
   private static void assertBoundAndReorderedCompletion(int bound) throws Exception {
     int expected = Math.min(bound, 16);
     List<CompletableFuture<AppendRowsResponse>> completions = new CopyOnWriteArrayList<>();
@@ -93,5 +128,38 @@ class BoundedAppendPipelineTest {
       rows.add(new JSONObject().put("id", i));
     }
     return rows;
+  }
+
+  private static class NeverCompletingFuture implements Future<AppendRowsResponse> {
+    private final CountDownLatch getStarted = new CountDownLatch(1);
+    private final AtomicBoolean cancelAttempted = new AtomicBoolean();
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+      cancelAttempted.set(true);
+      return false;
+    }
+
+    @Override
+    public boolean isCancelled() {
+      return false;
+    }
+
+    @Override
+    public boolean isDone() {
+      return false;
+    }
+
+    @Override
+    public AppendRowsResponse get() throws InterruptedException {
+      getStarted.countDown();
+      new CountDownLatch(1).await();
+      throw new AssertionError("unreachable");
+    }
+
+    @Override
+    public AppendRowsResponse get(long timeout, TimeUnit unit) throws TimeoutException {
+      throw new TimeoutException();
+    }
   }
 }

--- a/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/ChangeSequenceNumberTest.java
+++ b/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/ChangeSequenceNumberTest.java
@@ -1,0 +1,57 @@
+package io.debezium.server.bigquery;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.debezium.DebeziumException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ChangeSequenceNumberTest {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Test
+  void formatsFourFixedWidthUppercaseHexSections() throws Exception {
+    String sequence = ChangeSequenceNumber.from(value(123456789, "mysql-bin.001234", 255, 10)).toString();
+    assertEquals("00000000075BCD15/00000000000004D2/00000000000000FF/000000000000000A", sequence);
+    assertTrue(sequence.matches("[0-9A-F]{16}(?:/[0-9A-F]{16}){3}"));
+  }
+
+  @Test
+  void binlogRotationChangesFileSection() throws Exception {
+    String first = ChangeSequenceNumber.from(value(1, "mysql-bin.000009", 2, 3)).toString();
+    String rotated = ChangeSequenceNumber.from(value(1, "mysql-bin.000010", 2, 3)).toString();
+    assertEquals("0000000000000009", first.split("/")[1]);
+    assertEquals("000000000000000A", rotated.split("/")[1]);
+    assertTrue(first.compareTo(rotated) < 0);
+  }
+
+  @Test
+  void positionAndRowBreakTimestampTies() throws Exception {
+    ChangeSequenceNumber first = ChangeSequenceNumber.from(value(10, "bin.1", 20, 30));
+    ChangeSequenceNumber laterPosition = ChangeSequenceNumber.from(value(10, "bin.1", 21, 0));
+    ChangeSequenceNumber laterRow = ChangeSequenceNumber.from(value(10, "bin.1", 20, 31));
+    assertTrue(first.compareTo(laterPosition) < 0);
+    assertTrue(first.compareTo(laterRow) < 0);
+  }
+
+  @Test
+  void missingAndMalformedFieldsFailFast() throws Exception {
+    JsonNode missing = MAPPER.readTree("{\"__source_ts_ns\":1}");
+    assertTrue(assertThrows(DebeziumException.class, () -> ChangeSequenceNumber.from(missing))
+        .getMessage().contains("__source_file"));
+    assertTrue(assertThrows(DebeziumException.class,
+        () -> ChangeSequenceNumber.from(value(1, "mysql-bin.current", 2, 3))).getMessage().contains("numeric component"));
+    JsonNode negative = MAPPER.readTree("{\"__source_ts_ns\":-1,\"__source_file\":\"bin.1\",\"__source_pos\":2,\"__source_row\":3}");
+    assertTrue(assertThrows(DebeziumException.class, () -> ChangeSequenceNumber.from(negative))
+        .getMessage().contains("__source_ts_ns"));
+  }
+
+  private static JsonNode value(long timestamp, String file, long position, long row) throws Exception {
+    return MAPPER.readTree(String.format(
+        "{\"__source_ts_ns\":%d,\"__source_file\":\"%s\",\"__source_pos\":%d,\"__source_row\":%d}",
+        timestamp, file, position, row));
+  }
+}

--- a/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/ChangeSequenceNumberTest.java
+++ b/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/ChangeSequenceNumberTest.java
@@ -38,10 +38,21 @@ class ChangeSequenceNumberTest {
   }
 
   @Test
+  void postgresUsesLsnAndTransactionIdCoordinates() throws Exception {
+    ChangeSequenceNumber first = ChangeSequenceNumber.from(postgresValue(10, 255, 41));
+    ChangeSequenceNumber laterLsn = ChangeSequenceNumber.from(postgresValue(10, 256, 1));
+    ChangeSequenceNumber laterTransaction = ChangeSequenceNumber.from(postgresValue(10, 255, 42));
+    assertEquals("000000000000000A/00000000000000FF/0000000000000029/0000000000000000",
+        first.toString());
+    assertTrue(first.compareTo(laterLsn) < 0);
+    assertTrue(first.compareTo(laterTransaction) < 0);
+  }
+
+  @Test
   void missingAndMalformedFieldsFailFast() throws Exception {
     JsonNode missing = MAPPER.readTree("{\"__source_ts_ns\":1}");
     assertTrue(assertThrows(DebeziumException.class, () -> ChangeSequenceNumber.from(missing))
-        .getMessage().contains("__source_file"));
+        .getMessage().contains("no supported source coordinates"));
     assertTrue(assertThrows(DebeziumException.class,
         () -> ChangeSequenceNumber.from(value(1, "mysql-bin.current", 2, 3))).getMessage().contains("numeric component"));
     JsonNode negative = MAPPER.readTree("{\"__source_ts_ns\":-1,\"__source_file\":\"bin.1\",\"__source_pos\":2,\"__source_row\":3}");
@@ -53,5 +64,11 @@ class ChangeSequenceNumberTest {
     return MAPPER.readTree(String.format(
         "{\"__source_ts_ns\":%d,\"__source_file\":\"%s\",\"__source_pos\":%d,\"__source_row\":%d}",
         timestamp, file, position, row));
+  }
+
+  private static JsonNode postgresValue(long timestamp, long lsn, long transactionId) throws Exception {
+    return MAPPER.readTree(String.format(
+        "{\"__source_ts_ns\":%d,\"__source_lsn\":%d,\"__source_txId\":%d}",
+        timestamp, lsn, transactionId));
   }
 }

--- a/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/ChangeSequenceNumberTest.java
+++ b/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/ChangeSequenceNumberTest.java
@@ -38,14 +38,31 @@ class ChangeSequenceNumberTest {
   }
 
   @Test
-  void postgresUsesLsnAndTransactionIdCoordinates() throws Exception {
-    ChangeSequenceNumber first = ChangeSequenceNumber.from(postgresValue(10, 255, 41));
-    ChangeSequenceNumber laterLsn = ChangeSequenceNumber.from(postgresValue(10, 256, 1));
-    ChangeSequenceNumber laterTransaction = ChangeSequenceNumber.from(postgresValue(10, 255, 42));
-    assertEquals("000000000000000A/00000000000000FF/0000000000000029/0000000000000000",
+  void postgresUsesLsnTransactionIdAndEventOrderCoordinates() throws Exception {
+    ChangeSequenceNumber first = ChangeSequenceNumber.from(postgresValue(10, "255", 41, 7));
+    ChangeSequenceNumber laterLsn = ChangeSequenceNumber.from(postgresValue(10, "256", 1, 1));
+    ChangeSequenceNumber laterTransaction = ChangeSequenceNumber.from(postgresValue(10, "255", 42, 1));
+    ChangeSequenceNumber laterInTransaction = ChangeSequenceNumber.from(postgresValue(10, "255", 41, 8));
+    assertEquals("000000000000000A/00000000000000FF/0000000000000029/0000000000000007",
         first.toString());
     assertTrue(first.compareTo(laterLsn) < 0);
     assertTrue(first.compareTo(laterTransaction) < 0);
+    assertTrue(first.compareTo(laterInTransaction) < 0);
+  }
+
+  @Test
+  void postgresAcceptsFormattedHexadecimalLsn() throws Exception {
+    ChangeSequenceNumber sequence = ChangeSequenceNumber.from(postgresValue(10, "\"0/16B3748\"", 41, 7));
+    assertEquals("000000000000000A/00000000016B3748/0000000000000029/0000000000000007",
+        sequence.toString());
+  }
+
+  @Test
+  void postgresRequiresTransactionEventOrder() throws Exception {
+    JsonNode missingOrder = MAPPER.readTree(
+        "{\"__source_ts_ns\":10,\"__source_lsn\":255,\"__source_txId\":41}");
+    assertTrue(assertThrows(DebeziumException.class, () -> ChangeSequenceNumber.from(missingOrder))
+        .getMessage().contains("__transaction_total_order"));
   }
 
   @Test
@@ -66,9 +83,10 @@ class ChangeSequenceNumberTest {
         timestamp, file, position, row));
   }
 
-  private static JsonNode postgresValue(long timestamp, long lsn, long transactionId) throws Exception {
+  private static JsonNode postgresValue(long timestamp, String lsn, long transactionId, long transactionOrder)
+      throws Exception {
     return MAPPER.readTree(String.format(
-        "{\"__source_ts_ns\":%d,\"__source_lsn\":%d,\"__source_txId\":%d}",
-        timestamp, lsn, transactionId));
+        "{\"__source_ts_ns\":%d,\"__source_lsn\":%s,\"__source_txId\":%d,\"__transaction_total_order\":%d}",
+        timestamp, lsn, transactionId, transactionOrder));
   }
 }

--- a/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/StreamCdcSequencingTest.java
+++ b/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/StreamCdcSequencingTest.java
@@ -74,6 +74,17 @@ class StreamCdcSequencingTest {
     assertEquals(firstAttempt.getString("_CHANGE_TYPE"), replay.getString("_CHANGE_TYPE"));
   }
 
+  @Test
+  void postgresCdcMutationReceivesSequence() throws Exception {
+    JsonNode value = MAPPER.readTree(
+        "{\"id\":1,\"__op\":\"u\",\"__source_ts_ns\":100,\"__source_lsn\":200,\"__source_txId\":300}");
+    JsonNode key = MAPPER.readTree("{\"id\":1}");
+    JSONObject converted = new StreamRecordConverter("test", value, key, null, null, null)
+        .convert(null, true, false, true);
+    assertEquals("0000000000000064/00000000000000C8/000000000000012C/0000000000000000",
+        converted.getString(ChangeSequenceNumber.PSEUDO_COLUMN));
+  }
+
   private static boolean hasField(TableSchema schema, String name) {
     return schema.getFieldsList().stream().anyMatch(field -> field.getName().equals(name));
   }

--- a/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/StreamCdcSequencingTest.java
+++ b/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/StreamCdcSequencingTest.java
@@ -1,0 +1,88 @@
+package io.debezium.server.bigquery;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.cloud.bigquery.storage.v1.TableSchema;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class StreamCdcSequencingTest {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Test
+  void disabledSequencingDoesNotAddPseudocolumn() throws Exception {
+    JSONObject converted = converter("u", 1, 2, 3).convert(null, true, false, false);
+    assertEquals("UPSERT", converted.getString("_CHANGE_TYPE"));
+    assertFalse(converted.has(ChangeSequenceNumber.PSEUDO_COLUMN));
+  }
+
+  @Test
+  void allCdcMutationTypesReceiveSequence() throws Exception {
+    JSONObject upsert = converter("u", 1, 2, 3).convert(null, true, false, true);
+    JSONObject retainedDelete = converter("d", 1, 2, 4).convert(null, true, true, true);
+    JSONObject delete = converter("d", 1, 2, 5).convert(null, true, false, true);
+    assertEquals("UPSERT", upsert.getString("_CHANGE_TYPE"));
+    assertEquals("UPSERT", retainedDelete.getString("_CHANGE_TYPE"));
+    assertEquals("DELETE", delete.getString("_CHANGE_TYPE"));
+    assertNotNull(upsert.get(ChangeSequenceNumber.PSEUDO_COLUMN));
+    assertNotNull(retainedDelete.get(ChangeSequenceNumber.PSEUDO_COLUMN));
+    assertNotNull(delete.get(ChangeSequenceNumber.PSEUDO_COLUMN));
+  }
+
+  @Test
+  void storageSchemaContainsSequenceOnlyForSequencedCdc() {
+    Schema physical = Schema.of(Field.of("id", StandardSQLTypeName.INT64));
+    TableSchema append = StorageWriteSchemaConverter.toStorageTableSchema(physical, false, true);
+    TableSchema unsequencedCdc = StorageWriteSchemaConverter.toStorageTableSchema(physical, true, false);
+    TableSchema sequencedCdc = StorageWriteSchemaConverter.toStorageTableSchema(physical, true, true);
+    assertFalse(hasField(append, ChangeSequenceNumber.PSEUDO_COLUMN));
+    assertFalse(hasField(unsequencedCdc, ChangeSequenceNumber.PSEUDO_COLUMN));
+    assertTrue(hasField(sequencedCdc, ChangeSequenceNumber.PSEUDO_COLUMN));
+    assertFalse(physical.getFields().stream().anyMatch(field -> field.getName().equals(ChangeSequenceNumber.PSEUDO_COLUMN)));
+  }
+
+  @Test
+  void deduplicationUsesCompleteSourceCoordinate() throws Exception {
+    StreamBigqueryChangeConsumer consumer = new StreamBigqueryChangeConsumer();
+    consumer.config = mock(StreamConsumerConfig.class);
+    when(consumer.config.changeSequenceEnabled()).thenReturn(true);
+    StreamRecordConverter earlier = converter("d", 100, 20, 1);
+    StreamRecordConverter later = converter("c", 100, 20, 2);
+    List<RecordConverter> result = consumer.deduplicateBatch(List.of(earlier, later));
+    assertEquals(1, result.size());
+    assertEquals(2, result.get(0).value().get("__source_row").asInt());
+  }
+
+  @Test
+  void replayProducesTheSameSequencedMutation() throws Exception {
+    JSONObject firstAttempt = converter("u", 100, 20, 3).convert(null, true, false, true);
+    JSONObject replay = converter("u", 100, 20, 3).convert(null, true, false, true);
+    assertEquals(firstAttempt.getString(ChangeSequenceNumber.PSEUDO_COLUMN),
+        replay.getString(ChangeSequenceNumber.PSEUDO_COLUMN));
+    assertEquals(firstAttempt.getString("_CHANGE_TYPE"), replay.getString("_CHANGE_TYPE"));
+  }
+
+  private static boolean hasField(TableSchema schema, String name) {
+    return schema.getFieldsList().stream().anyMatch(field -> field.getName().equals(name));
+  }
+
+  private static StreamRecordConverter converter(String operation, long timestamp, long position, long row) throws Exception {
+    JsonNode value = MAPPER.readTree(String.format(
+        "{\"id\":1,\"__op\":\"%s\",\"__source_ts_ns\":%d,\"__source_file\":\"mysql-bin.000007\",\"__source_pos\":%d,\"__source_row\":%d}",
+        operation, timestamp, position, row));
+    JsonNode key = MAPPER.readTree("{\"id\":1}");
+    return new StreamRecordConverter("test", value, key, null, null, null);
+  }
+}

--- a/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/StreamCdcSequencingTest.java
+++ b/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/StreamCdcSequencingTest.java
@@ -77,11 +77,12 @@ class StreamCdcSequencingTest {
   @Test
   void postgresCdcMutationReceivesSequence() throws Exception {
     JsonNode value = MAPPER.readTree(
-        "{\"id\":1,\"__op\":\"u\",\"__source_ts_ns\":100,\"__source_lsn\":200,\"__source_txId\":300}");
+        "{\"id\":1,\"__op\":\"u\",\"__source_ts_ns\":100,\"__source_lsn\":200,"
+            + "\"__source_txId\":300,\"__transaction_total_order\":4}");
     JsonNode key = MAPPER.readTree("{\"id\":1}");
     JSONObject converted = new StreamRecordConverter("test", value, key, null, null, null)
         .convert(null, true, false, true);
-    assertEquals("0000000000000064/00000000000000C8/000000000000012C/0000000000000000",
+    assertEquals("0000000000000064/00000000000000C8/000000000000012C/0000000000000004",
         converted.getString(ChangeSequenceNumber.PSEUDO_COLUMN));
   }
 

--- a/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/StreamConsumerConfigTest.java
+++ b/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/StreamConsumerConfigTest.java
@@ -1,0 +1,29 @@
+package io.debezium.server.bigquery;
+
+import io.debezium.DebeziumException;
+import io.smallrye.config.WithDefault;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class StreamConsumerConfigTest {
+  @Test
+  void sequencingAndAppendDefaultsAreBackwardCompatible() throws Exception {
+    WithDefault sequenceDefault = StreamConsumerConfig.class.getMethod("changeSequenceEnabled").getAnnotation(WithDefault.class);
+    WithDefault inFlightDefault = StreamConsumerConfig.class.getMethod("maxInFlightAppends").getAnnotation(WithDefault.class);
+    assertEquals("false", sequenceDefault.value());
+    assertEquals("1", inFlightDefault.value());
+  }
+
+  @Test
+  void zeroInFlightAppendsIsRejectedBeforeConnecting() {
+    StreamBigqueryChangeConsumer consumer = new StreamBigqueryChangeConsumer();
+    consumer.config = mock(StreamConsumerConfig.class);
+    when(consumer.config.maxInFlightAppends()).thenReturn(0);
+    DebeziumException error = assertThrows(DebeziumException.class, consumer::initialize);
+    assertEquals("debezium.sink.bigquerystream.max-in-flight-appends must be at least 1, but was 0", error.getMessage());
+  }
+}

--- a/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/StreamDataWriterTest.java
+++ b/debezium-server-bigquery-sinks/src/test/java/io/debezium/server/bigquery/StreamDataWriterTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright memiiso Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.server.bigquery;
+
+import com.google.cloud.bigquery.storage.v1.AppendRowsResponse;
+import com.google.rpc.Status;
+import io.debezium.DebeziumException;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class StreamDataWriterTest {
+  @Test
+  void successfulPipelinedAppendResetsRecreationBudget() throws Exception {
+    StreamDataWriter writer = writerReturning(AppendRowsResponse.getDefaultInstance());
+    AtomicInteger recreateCount = recreateCount(writer);
+    recreateCount.set(3);
+
+    writer.appendPipelined(List.of(new JSONObject().put("id", 1)), 2);
+
+    assertEquals(0, recreateCount.get());
+  }
+
+  @Test
+  void failedPipelinedAppendPreservesRecreationBudget() throws Exception {
+    AppendRowsResponse failure = AppendRowsResponse.newBuilder()
+        .setError(Status.newBuilder().setCode(3).setMessage("bad append"))
+        .build();
+    StreamDataWriter writer = writerReturning(failure);
+    AtomicInteger recreateCount = recreateCount(writer);
+    recreateCount.set(3);
+
+    assertThrows(DebeziumException.class,
+        () -> writer.appendPipelined(List.of(new JSONObject().put("id", 1)), 2));
+
+    assertEquals(3, recreateCount.get());
+  }
+
+  private static StreamDataWriter writerReturning(AppendRowsResponse response) throws Exception {
+    return new StreamDataWriter("table", null, false, null, null) {
+      @Override
+      Future<AppendRowsResponse> appendAsync(JSONArray data) {
+        return CompletableFuture.completedFuture(response);
+      }
+    };
+  }
+
+  private static AtomicInteger recreateCount(StreamDataWriter writer) throws Exception {
+    Field field = StreamDataWriter.class.getDeclaredField("recreateCount");
+    field.setAccessible(true);
+    return (AtomicInteger) field.get(writer);
+  }
+}

--- a/docs/bigquerystream.md
+++ b/docs/bigquerystream.md
@@ -57,22 +57,33 @@ UPSERT and DELETE mutation receives the Storage Write API pseudocolumn `_CHANGE_
 (`upsert-keep-deletes=true`) receive both an UPSERT change type and a sequence. The pseudocolumn is included in the
 Storage Write protobuf schema but is never created as a physical BigQuery table column.
 
-Configure the Debezium unwrap transform to expose all required source fields:
+Configure the Debezium unwrap transform to expose all required source fields for the source connector.
+
+For MySQL:
 
 ```properties
 debezium.transforms.unwrap.add.fields=op,source.ts_ms,source.ts_ns,source.file,source.pos,source.row
 debezium.sink.bigquerystream.change-sequence.enabled=true
 ```
 
-The sequence format is four uppercase, zero-padded, 16-character hexadecimal sections:
+For PostgreSQL:
+
+```properties
+debezium.transforms.unwrap.add.fields=op,source.ts_ms,source.ts_ns,source.lsn,source.txId
+debezium.sink.bigquerystream.change-sequence.enabled=true
+```
+
+Sequences use four uppercase, zero-padded, 16-character hexadecimal sections. The source-specific section order is:
 
 ```text
-source.ts_ns/binlog-file-index/source.pos/source.row
+MySQL:      source.ts_ns/binlog-file-index/source.pos/source.row
+PostgreSQL: source.ts_ns/source.lsn/source.txId/0
 %016X/%016X/%016X/%016X
 ```
 
 The binlog file index is the trailing numeric component of `__source_file` (for example, `mysql-bin.001234` becomes
-`1234`). `__source_ts_ns`, `__source_file`, `__source_pos`, and `__source_row` must be present and valid on every CDC
+`1234`). MySQL requires `__source_ts_ns`, `__source_file`, `__source_pos`, and `__source_row`; PostgreSQL requires
+`__source_ts_ns`, `__source_lsn`, and `__source_txId`. The appropriate fields must be present and valid on every CDC
 mutation. Missing, malformed, negative, or larger-than-64-bit components fail the complete Debezium batch; the connector
 does not silently emit an unsequenced mutation.
 
@@ -84,10 +95,10 @@ of `1` preserves the synchronous single-append behavior. Values above 1 split a 
 balanced chunks, submit them to the BigQuery default stream, and wait for every response even when completions arrive out
 of order.
 
-An append response error, exception, cancellation, timeout, or interruption fails the whole batch. Already-submitted
-futures are observed before failure is reported, and Debezium offsets are not marked processed or batch-finished unless
-every destination and every append succeeds. Replaying a failed sequenced batch is safe because source coordinates produce
-the same ordering values.
+An append response error, exception, cancellation, timeout, or interruption fails the whole batch. On interruption,
+outstanding append futures are cancelled and the interrupt status is restored without waiting indefinitely for an
+unresponsive request. Debezium offsets are not marked processed or batch-finished unless every destination and every
+append succeeds. Replaying a failed sequenced batch is safe because source coordinates produce the same ordering values.
 
 Benchmark values above 1 for the workload. For upsert destinations, use change sequencing when enabling append
 pipelining so out-of-order append completion cannot change the final CDC state.

--- a/docs/bigquerystream.md
+++ b/docs/bigquerystream.md
@@ -24,6 +24,8 @@ the [Storage Write API](https://cloud.google.com/bigquery/docs/write-api-streami
 | `debezium.sink.bigquerystream.upsert-keep-deletes`       | `true`           | With upsert mode, keeps deleted rows in bigquery table.                                                                                |
 | `debezium.sink.bigquerystream.upsert-dedup-column`       | `__source_ts_ns` | With upsert mode used to deduplicate data. row with highest `__source_ts_ns` is kept.                                                  |
 | `debezium.sink.bigquerystream.upsert-op-column`          | `__op`           | Used with upsert mode to deduplicate data when `__source_ts_ns` of rows are same.                                                      |
+| `debezium.sink.bigquerystream.change-sequence.enabled`   | `false`          | Add BigQuery `_CHANGE_SEQUENCE_NUMBER` custom CDC ordering values to every CDC mutation.                                              |
+| `debezium.sink.bigquerystream.max-in-flight-appends`     | `1`              | Maximum append requests pipelined within one destination batch. Values below 1 are rejected.                                         |
 | `debezium.sink.bigquerystream.cast-deleted-field`        | `false`          | Cast deleted field to boolean type(by default it is string type)                                                                       |
 
 ### Upsert
@@ -45,3 +47,47 @@ Operation type priorities are `{"c":1, "r":2, "u":3, "d":4}`. When two records w
 values received then the record with higher `__op` priority is kept and added to destination table and duplicate record
 is dropped from stream.
 
+When `debezium.sink.bigquerystream.change-sequence.enabled=true`, deduplication instead compares the complete source
+coordinate described below. This resolves ties across binlog files, positions, and rows at the same nanosecond.
+
+### Custom CDC ordering
+
+Change sequencing is optional and only applies to tables that actually use BigQuery CDC/upsert mode. When enabled, every
+UPSERT and DELETE mutation receives the Storage Write API pseudocolumn `_CHANGE_SEQUENCE_NUMBER`; retained delete rows
+(`upsert-keep-deletes=true`) receive both an UPSERT change type and a sequence. The pseudocolumn is included in the
+Storage Write protobuf schema but is never created as a physical BigQuery table column.
+
+Configure the Debezium unwrap transform to expose all required source fields:
+
+```properties
+debezium.transforms.unwrap.add.fields=op,source.ts_ms,source.ts_ns,source.file,source.pos,source.row
+debezium.sink.bigquerystream.change-sequence.enabled=true
+```
+
+The sequence format is four uppercase, zero-padded, 16-character hexadecimal sections:
+
+```text
+source.ts_ns/binlog-file-index/source.pos/source.row
+%016X/%016X/%016X/%016X
+```
+
+The binlog file index is the trailing numeric component of `__source_file` (for example, `mysql-bin.001234` becomes
+`1234`). `__source_ts_ns`, `__source_file`, `__source_pos`, and `__source_row` must be present and valid on every CDC
+mutation. Missing, malformed, negative, or larger-than-64-bit components fail the complete Debezium batch; the connector
+does not silently emit an unsequenced mutation.
+
+### Append and destination concurrency
+
+`debezium.sink.batch.concurrent-uploads` processes different destination tables concurrently.
+`debezium.sink.bigquerystream.max-in-flight-appends` pipelines append requests within one destination. The default value
+of `1` preserves the synchronous single-append behavior. Values above 1 split a destination batch into at most that many
+balanced chunks, submit them to the BigQuery default stream, and wait for every response even when completions arrive out
+of order.
+
+An append response error, exception, cancellation, timeout, or interruption fails the whole batch. Already-submitted
+futures are observed before failure is reported, and Debezium offsets are not marked processed or batch-finished unless
+every destination and every append succeeds. Replaying a failed sequenced batch is safe because source coordinates produce
+the same ordering values.
+
+Benchmark values above 1 for the workload. For upsert destinations, use change sequencing when enabling append
+pipelining so out-of-order append completion cannot change the final CDC state.

--- a/docs/bigquerystream.md
+++ b/docs/bigquerystream.md
@@ -69,7 +69,8 @@ debezium.sink.bigquerystream.change-sequence.enabled=true
 For PostgreSQL:
 
 ```properties
-debezium.transforms.unwrap.add.fields=op,source.ts_ms,source.ts_ns,source.lsn,source.txId
+debezium.source.provide.transaction.metadata=true
+debezium.transforms.unwrap.add.fields=op,source.ts_ms,source.ts_ns,source.lsn,source.txId,transaction.total_order
 debezium.sink.bigquerystream.change-sequence.enabled=true
 ```
 
@@ -77,15 +78,17 @@ Sequences use four uppercase, zero-padded, 16-character hexadecimal sections. Th
 
 ```text
 MySQL:      source.ts_ns/binlog-file-index/source.pos/source.row
-PostgreSQL: source.ts_ns/source.lsn/source.txId/0
+PostgreSQL: source.ts_ns/source.lsn/source.txId/transaction.total_order
 %016X/%016X/%016X/%016X
 ```
 
 The binlog file index is the trailing numeric component of `__source_file` (for example, `mysql-bin.001234` becomes
 `1234`). MySQL requires `__source_ts_ns`, `__source_file`, `__source_pos`, and `__source_row`; PostgreSQL requires
-`__source_ts_ns`, `__source_lsn`, and `__source_txId`. The appropriate fields must be present and valid on every CDC
-mutation. Missing, malformed, negative, or larger-than-64-bit components fail the complete Debezium batch; the connector
-does not silently emit an unsequenced mutation.
+`__source_ts_ns`, `__source_lsn`, `__source_txId`, and `__transaction_total_order`. PostgreSQL transaction metadata must
+be enabled so multiple row changes at the same LSN receive distinct ordering values. PostgreSQL LSN values can be
+Debezium's standard decimal integer or the conventional hexadecimal `X/Y` format. The appropriate fields must be present
+and valid on every CDC mutation. Missing, malformed, negative, or larger-than-64-bit components fail the complete
+Debezium batch; the connector does not silently emit an unsequenced mutation.
 
 ### Append and destination concurrency
 


### PR DESCRIPTION
## Summary

- add optional BigQuery `_CHANGE_SEQUENCE_NUMBER` support to every BigQuery CDC mutation, including UPSERT, DELETE, and retained delete rows
- generate deterministic four-section custom ordering keys for MySQL and PostgreSQL source coordinates
- add bounded asynchronous append pipelining within each destination while continuing to use the BigQuery default stream
- propagate append and destination failures so Debezium offsets advance only after the entire batch succeeds
- cancel outstanding appends on interruption, preserve interrupt status, and correct semaphore permit accounting
- add deterministic unit coverage and document configuration, ordering, and failure behavior

## Related work

Closes #277.

This builds on the dedicated BigQuery writer executor introduced in #362 and hardens the parallel destination upload path introduced in #324. The implementation was originally based on `0.11.0.Final` (`da177e1`) and has been forward-ported to current `master`.

BigQuery custom ordering contract: https://cloud.google.com/bigquery/docs/change-data-capture#manage_custom_ordering

## Configuration

Two sink settings are added:

- `debezium.sink.bigquerystream.change-sequence.enabled` — boolean, default `false`
- `debezium.sink.bigquerystream.max-in-flight-appends` — integer, default `1`; values below `1` are rejected at startup

The defaults retain the existing unsequenced, single synchronous append behavior.

PostgreSQL sequencing additionally requires Debezium transaction metadata and the transaction order field:

```properties
debezium.source.provide.transaction.metadata=true
debezium.transforms.unwrap.add.fields=op,source.ts_ms,source.ts_ns,source.lsn,source.txId,transaction.total_order
```

## Change sequence formats

Each component is an uppercase, zero-padded, 16-character hexadecimal value:

- MySQL: `source.ts_ns / binlog-file-index / source.pos / source.row`
- PostgreSQL: `source.ts_ns / source.lsn / source.txId / transaction.total_order`

PostgreSQL LSNs accept Debezium decimal integers and conventional hexadecimal `X/Y` values. `transaction.total_order` distinguishes multiple row changes with otherwise identical PostgreSQL coordinates.

The sequence pseudocolumn is added only to the Storage Write API protobuf schema for CDC/upsert destinations. It is not added to the physical BigQuery table schema. Missing, malformed, negative, or oversized coordinates fail the batch instead of emitting an unsequenced mutation.

When sequencing is enabled, in-batch deduplication compares the complete source coordinate. When disabled, the existing timestamp and operation-priority behavior is unchanged.

## Concurrency and failure model

`debezium.sink.batch.concurrent-uploads` controls concurrent processing across destination tables. `max-in-flight-appends` independently bounds append requests within one destination.

For values above `1`, a destination batch is divided into at most that many balanced, non-empty chunks. Every submitted future and every `AppendRowsResponse` is observed. A response error, exception, cancellation, timeout, or interruption fails the complete batch. On interruption, outstanding requests are cancelled without retrying an unbounded wait, and the interrupt status is restored.

Parallel destination failures are propagated through `handleBatch`, preventing both `markProcessed` and `markBatchFinished` after partial failure. Successful batches retain the existing commit behavior.
